### PR TITLE
Fix null exception when FeatureWeights is null

### DIFF
--- a/com.jlpm.motionmatching/Runtime/Core/MotionMatchingController.cs
+++ b/com.jlpm.motionmatching/Runtime/Core/MotionMatchingController.cs
@@ -117,7 +117,7 @@ namespace MotionMatching
             {
                 float[] newWeights = new float[numberFeatures];
                 for (int i = 0; i < newWeights.Length; ++i) newWeights[i] = 1.0f;
-                for (int i = 0; i < Mathf.Min(FeatureWeights.Length, newWeights.Length); i++) newWeights[i] = FeatureWeights[i];
+                for (int i = 0; i < Mathf.Min(FeatureWeights?.Length ?? 0, newWeights.Length); i++) newWeights[i] = FeatureWeights[i];
                 FeatureWeights = newWeights;
             }
             FeaturesWeightsNativeArray = new NativeArray<float>(FeatureSet.FeatureSize, Allocator.Persistent);


### PR DESCRIPTION
The original code at line 120 would always try to access FeatureWeights.Length even if the latter is null. The reparation is done by returning 0 when FeatureWeights is null, and will skip the loop.